### PR TITLE
improvement/GH-107: Move shared examples for api controller specs

### DIFF
--- a/spec/controllers/api/boards_controller_spec.rb
+++ b/spec/controllers/api/boards_controller_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe API::BoardsController do
     let_it_be(:params) { { slug: board.slug } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
       context 'when user is not a board member' do
         before { login_as not_member }
-        it_behaves_like 'an unauthorized action'
+        it_behaves_like :controllers_api_unauthorized_action
       end
 
       context 'when user is a board member' do
@@ -34,7 +34,7 @@ RSpec.describe API::BoardsController do
             }
           end
 
-          it_behaves_like 'a failed action'
+          it_behaves_like :controllers_api_failed_action
         end
 
         context 'when params are valid' do
@@ -44,7 +44,7 @@ RSpec.describe API::BoardsController do
             }
           end
 
-          it_behaves_like 'a successful action'
+          it_behaves_like :controllers_api_successful_action
           it { is_expected.to match_json_schema('api/boards/invite') }
           it 'invites only nonmembers' do
             expect(json_body.map { |h| h.dig('user', 'email') })
@@ -60,13 +60,13 @@ RSpec.describe API::BoardsController do
     let_it_be(:params) { { slug: board.slug } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
       context 'when user is not a board member' do
         before { login_as not_member }
-        it_behaves_like 'an unauthorized action'
+        it_behaves_like :controllers_api_unauthorized_action
       end
 
       context 'when user is a board member' do
@@ -79,7 +79,7 @@ RSpec.describe API::BoardsController do
         context 'when autocomplete param value is an empty string' do
           let_it_be(:params) { params.merge autocomplete: '' }
 
-          it_behaves_like 'a successful action'
+          it_behaves_like :controllers_api_successful_action
           it { is_expected.to match_json_schema('api/boards/suggestions') }
           it 'responds with a list of all users and teams from db' do
             expect(json_body['users']).not_to be_empty
@@ -90,7 +90,7 @@ RSpec.describe API::BoardsController do
         context 'when autocomplete param has value' do
           let_it_be(:params) { params.merge autocomplete: 'suggestion' }
 
-          it_behaves_like 'a successful action'
+          it_behaves_like :controllers_api_successful_action
           it { is_expected.to match_json_schema('api/boards/suggestions') }
           it 'responds with a list of users and teams from db that fit query case insensitively' do
             expect(json_body['users'])

--- a/spec/controllers/api/cards_controller_spec.rb
+++ b/spec/controllers/api/cards_controller_spec.rb
@@ -11,18 +11,18 @@ RSpec.describe API::CardsController do
     let_it_be(:params) { { board_slug: board.slug, id: card.id } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged in' do
       context 'when user is not the card author' do
         before { login_as not_author }
-        it_behaves_like 'an unauthorized action'
+        it_behaves_like :controllers_api_unauthorized_action
       end
 
       context 'when user is the card author' do
         before { login_as author }
-        it_behaves_like 'a successful action', :no_content
+        it_behaves_like :controllers_api_successful_action, :no_content
       end
     end
   end
@@ -38,13 +38,13 @@ RSpec.describe API::CardsController do
     end
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
       context 'when user is not the card author' do
         before { login_as not_author }
-        it_behaves_like 'an unauthorized action'
+        it_behaves_like :controllers_api_unauthorized_action
       end
 
       context 'when user is the card author' do
@@ -52,11 +52,11 @@ RSpec.describe API::CardsController do
 
         context 'when params are not valid' do
           let_it_be(:params) { params.merge edited_body: nil }
-          it_behaves_like 'a failed action'
+          it_behaves_like :controllers_api_failed_action
         end
 
         context 'when params are valid' do
-          it_behaves_like 'a successful action'
+          it_behaves_like :controllers_api_successful_action
           it { is_expected.to match_json_schema('api/cards/update') }
           it { expect(json_body['updated_body']).to eq params[:edited_body] }
         end

--- a/spec/controllers/api/memberships_controller_spec.rb
+++ b/spec/controllers/api/memberships_controller_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe API::MembershipsController do
     let_it_be(:params) { { board_slug: board.slug } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
       before { login_as not_member }
 
-      it_behaves_like 'a successful action'
+      it_behaves_like :controllers_api_successful_action
       it { is_expected.to match_json_schema('api/memberships/index') }
       it 'responds with a list of all board members' do
         expect(json_body.map { |h| h.dig('user', 'email') })
@@ -37,18 +37,18 @@ RSpec.describe API::MembershipsController do
     let_it_be(:params) { { board_slug: board.slug, id: membership.id } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
       context 'when user is not a board creator' do
         before { login_as member }
-        it_behaves_like 'an unauthorized action'
+        it_behaves_like :controllers_api_unauthorized_action
       end
 
       context 'when user is the board creator' do
         before { login_as creator }
-        it_behaves_like 'a successful action', :no_content
+        it_behaves_like :controllers_api_successful_action, :no_content
       end
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe API::MembershipsController do
     let_it_be(:params) { { board_slug: board.slug, id: membership.id } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
@@ -69,7 +69,7 @@ RSpec.describe API::MembershipsController do
 
       context 'when user is the board member' do
         before { login_as member }
-        it_behaves_like 'a successful action'
+        it_behaves_like :controllers_api_successful_action
         it 'responds with default boolean false ready status for newly created membership' do
           expect(json_body).to eq false
         end
@@ -82,7 +82,7 @@ RSpec.describe API::MembershipsController do
     let_it_be(:params) { { board_slug: board.slug, id: membership.id } }
 
     context 'when user is not logged in' do
-      it_behaves_like 'an unauthenticated action'
+      it_behaves_like :controllers_api_unauthenticated_action
     end
 
     context 'when user is logged_in' do
@@ -93,7 +93,7 @@ RSpec.describe API::MembershipsController do
 
       context 'when user is the board member' do
         before { login_as member }
-        it_behaves_like 'a successful action'
+        it_behaves_like :controllers_api_successful_action
         it 'switches boolean ready status value for existing memberships' do
           expect(json_body).to eq true
         end

--- a/spec/support/shared_examples/controllers/api/failed_action.rb
+++ b/spec/support/shared_examples/controllers/api/failed_action.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a failed action' do
+RSpec.shared_examples :controllers_api_failed_action do
   it { is_expected.to have_http_status(:bad_request) }
 end

--- a/spec/support/shared_examples/controllers/api/successful_action.rb
+++ b/spec/support/shared_examples/controllers/api/successful_action.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a successful action' do |code = :ok|
+RSpec.shared_examples :controllers_api_successful_action do |code = :ok|
   it { is_expected.to have_http_status(code) }
 end

--- a/spec/support/shared_examples/controllers/api/unauthenticated_action.rb
+++ b/spec/support/shared_examples/controllers/api/unauthenticated_action.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'an unauthenticated action' do
+RSpec.shared_examples :controllers_api_unauthenticated_action do
   it { is_expected.to have_http_status(:found) }
 end

--- a/spec/support/shared_examples/controllers/api/unauthorized_action.rb
+++ b/spec/support/shared_examples/controllers/api/unauthorized_action.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'an unauthorized action' do
+RSpec.shared_examples :controllers_api_unauthorized_action do
   it { is_expected.to have_http_status(:unauthorized) }
 end


### PR DESCRIPTION
Moved shared examples for api controller to api namespace due to naming overlap with regular controller shared examples. 