### PR TITLE
fix/GH-118: Prevent card columns extension on boards#show

### DIFF
--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -23,7 +23,10 @@ class BoardsController < ApplicationController
     }
     @action_items = @board.action_items
     @action_item = ActionItem.new(board_id: @board.id)
-    @previous_action_items = @board.previous_board.action_items unless @board.previous_board.nil?
+
+    @previous_action_items = if @board.previous_board&.action_items&.any?
+                               @board.previous_board.action_items
+                             end
   end
   # rubocop: enable Metrics/AbcSize
 

--- a/app/javascript/components/ActionItem/ActionItem.css
+++ b/app/javascript/components/ActionItem/ActionItem.css
@@ -1,1 +1,2 @@
 .box { margin-bottom: 1.5rem; }
+

--- a/app/javascript/components/ActionItem/ActionItemBody/ActionItemBody.css
+++ b/app/javascript/components/ActionItem/ActionItemBody/ActionItemBody.css
@@ -7,3 +7,5 @@ textarea {
            line-height: 1.5;           
            color: hsl(0, 0%, 29%);
          }
+
+.text { overflow-wrap: break-word; }

--- a/app/javascript/components/ActionItem/ActionItemBody/index.js
+++ b/app/javascript/components/ActionItem/ActionItemBody/index.js
@@ -64,7 +64,7 @@ class ActionItemBody extends React.Component {
 
     return (
       <div> 
-        <div onDoubleClick={editable && this.editModeToggle} hidden={editMode}>
+        <div className='text' onDoubleClick={editable && this.editModeToggle} hidden={editMode}>
           {inputValue}
         </div>
 

--- a/app/javascript/components/Card/Card.css
+++ b/app/javascript/components/Card/Card.css
@@ -1,1 +1,2 @@
 .box { margin-bottom: 1.5rem; }
+

--- a/app/javascript/components/Card/CardBody/CardBody.css
+++ b/app/javascript/components/Card/CardBody/CardBody.css
@@ -7,3 +7,5 @@ textarea {
            line-height: 1.5;           
            color: hsl(0, 0%, 29%);
          }
+
+.text { overflow-wrap: break-word; }

--- a/app/javascript/components/Card/CardBody/index.js
+++ b/app/javascript/components/Card/CardBody/index.js
@@ -64,7 +64,7 @@ class CardBody extends React.Component {
 
     return (
       <div> 
-        <div onDoubleClick={editable && this.editModeToggle} hidden={editMode}>
+        <div className='text' onDoubleClick={editable && this.editModeToggle} hidden={editMode}>
           {inputValue}
         </div>
         <Textarea value={inputValue} 

--- a/app/views/boards/show.html.erb
+++ b/app/views/boards/show.html.erb
@@ -37,9 +37,15 @@
 <div class="box" id='autocomplete'>
 </div>
 
+<% if @previous_action_items %>
+  <% column_class_name = 'column is-one-fifth' %>
+<% else %>
+  <% column_class_name = 'column is-one-quarter' %>
+<% end %>
+
 <div class='columns'>
   <% if @previous_action_items %>
-    <div class='column'>
+    <div class='<%= column_class_name %>'>
       <h2 class='subtitle'>
        PREVIOUS BOARD
       </h2>
@@ -49,7 +55,7 @@
     </div>
   <% end %>
   <% @cards_by_type.each do |kind, cards| %>
-    <div class='column'>
+    <div class='<%= column_class_name %>'>
       <h2 class='subtitle'>
         <%= kind.upcase %>
       </h2>
@@ -71,7 +77,7 @@
     </div>
   <% end %>
 
-  <div class='column'>
+  <div class='<%= column_class_name %>'>
     <h2 class='subtitle'>
       ACTION ITEMS
     </h2>


### PR DESCRIPTION
- set 'column is-a-quarter' or 'column is-a-fifth' classes for style constraints.
- add 'overflow-wrap: break-word;' style to text divs for correct line breaks.